### PR TITLE
Fix build dependencies to ensure pnpm restore runs before project references

### DIFF
--- a/AppHost/AppHost.csproj
+++ b/AppHost/AppHost.csproj
@@ -20,6 +20,16 @@
     <PackageReference Include="Aspire.Hosting.Python" Version="9.3.1" />
   </ItemGroup>
 
+  <!-- Restore pnpm packages for web projects during build -->
+  <Target Name="RestorePnpm" BeforeTargets="BeforeBuild;ResolveProjectReferences" Condition=" '$(DesignTimeBuild)' != 'true' ">
+    <ItemGroup>
+      <PackageJsons Include="..\*\package.json" />
+    </ItemGroup>
+    <!-- Install pnpm packages if node_modules is missing -->
+    <Message Importance="Normal" Text="Installing pnpm packages for %(PackageJsons.RelativeDir)" Condition="!Exists('%(PackageJsons.RootDir)%(PackageJsons.Directory)/node_modules')" />
+    <Exec Command="pnpm install" WorkingDirectory="%(PackageJsons.RootDir)%(PackageJsons.Directory)" Condition="!Exists('%(PackageJsons.RootDir)%(PackageJsons.Directory)/node_modules')" />
+  </Target>
+
   <Target Name="RestorePython" BeforeTargets="Build" Condition="'$DesignTimeBuild' != 'true' ">
     <ItemGroup>
       <RequirementsTxtFiles Include="..\*\requirements.txt" />


### PR DESCRIPTION
## Summary
- Updated `RestorePnpm` MSBuild target to run before `ResolveProjectReferences`
- Ensures node_modules are installed before any dependent projects are built
- Prevents build failures when web project dependencies are missing

## Test plan
- [ ] Run `dotnet build` from clean state (no node_modules)
- [ ] Verify pnpm packages are installed before ApiService builds
- [ ] Confirm AppHost starts successfully with all dependencies

🤖 Generated with [Claude Code](https://claude.ai/code)