### PR TITLE
Fix PUT API parameter naming and Content-Type header

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -55,7 +55,7 @@ export default function TodosPage() {
                             <TableCell>
                                 <Checkbox
                                     checked={todo.isComplete!}
-                                    onCheckedChange={() => updateTodo({ id: todo.id!, updateTodoCommand: { title: todo.title ?? "", isComplete: !todo.isComplete } })}
+                                    onCheckedChange={() => updateTodo({ id: todo.id!, updateTodoCommandDto: { title: todo.title ?? "", isComplete: !todo.isComplete } })}
                                 />
                             </TableCell>
                             <TableCell>{todo.title}</TableCell>

--- a/web/src/store/api/empty-api.ts
+++ b/web/src/store/api/empty-api.ts
@@ -2,7 +2,13 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 
 export const emptySplitApi = createApi({
   reducerPath: 'api',
-  baseQuery: fetchBaseQuery({ baseUrl: process.env.NEXT_PUBLIC_DOTNET_API_URL }),
+  baseQuery: fetchBaseQuery({ 
+    baseUrl: process.env.NEXT_PUBLIC_DOTNET_API_URL,
+    prepareHeaders: (headers) => {
+      headers.set('Content-Type', 'application/json')
+      return headers
+    },
+  }),
   endpoints: () => ({}),
 })
 


### PR DESCRIPTION
## Summary
- Fixed updateTodo parameter name mismatch between frontend and generated API client
- Added proper Content-Type header configuration to RTK Query base setup
- Ensures PUT requests work correctly with the .NET backend

## Test plan
- [x] Test updating todo items by clicking checkboxes
- [x] Verify PUT requests include Content-Type: application/json header
- [x] Confirm todos toggle between complete/incomplete states

🤖 Generated with [Claude Code](https://claude.ai/code)